### PR TITLE
Liz test

### DIFF
--- a/client/components/SingleProduct.js
+++ b/client/components/SingleProduct.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { fetchSingleProduct } from "../store/singleProduct";
 import {
@@ -30,10 +30,10 @@ const SingleProduct = (props) => {
 
   //establish whether this item is in the cart and if it is, how many
   let quantity = 0;
-  //if there is something in the cart, check if it is the item that is currently displayed
+  //if there is something in the cart, check if the cart includes this item.
   if (cart.length) {
     const [cartProduct] = cart.filter((item) => product.id === item.id);
-    //if the item currently displayed it in the cart, check how many
+    //if this item is in the cart, note its quantity
     if (cartProduct) {
       quantity = cartProduct.qty;
     }
@@ -55,7 +55,7 @@ const SingleProduct = (props) => {
         dispatch(goUpdateShoppingItemQty(product, userId, quantity + 1));
       } else {
         //if not loggedIn dispatch action to update the qty in store only.
-        dispatch(updateItemQty(product));
+        dispatch(updateItemQty(product, quantity + 1));
       }
     } else {
       //if item is not in the cart, add it to the cart in the store / db (with qty 1)

--- a/client/store/auth.js
+++ b/client/store/auth.js
@@ -44,7 +44,11 @@ export const me = () => async (dispatch) => {
         let [productInBackEndCart] = backEndCart.filter(
           (backEndProduct) => backEndProduct.id === frontEndProduct.id
         );
-        let newQuantity = productInBackEndCart.qty + frontEndProduct.qty;
+        let backEndQty = 0;
+        if (productInBackEndCart) {
+          backEndQty = productInBackEndCart.qty;
+        }
+        let newQuantity = backEndQty + frontEndProduct.qty;
         await dispatch(goAddShoppingItem(frontEndProduct, id, newQuantity));
       });
     }

--- a/client/store/auth.js
+++ b/client/store/auth.js
@@ -32,14 +32,18 @@ export const me = () => async (dispatch) => {
     const frontEndCart = JSON.parse(window.localStorage.getItem(CART));
     if (frontEndCart) {
       //go add the frontend cart to backEnd
-      frontEndCart.forEach((product) => {
+      frontEndCart.forEach(async (product) => {
+        console.log('product', product)
         dispatch(goAddShoppingItem(product, id, product.qty));
       });
     }
 
-    //get backend cart for this user.
-    dispatch(fetchCart(id));
-    return dispatch(setAuth(auth));
+    // //get backend cart for this user.
+    // return (dispatch) => {
+      dispatch(fetchCart(id));
+      dispatch(setAuth(auth));
+    // }
+    // return
   }
 };
 

--- a/client/store/auth.js
+++ b/client/store/auth.js
@@ -3,7 +3,7 @@ import history from "../history";
 import { fetchCart, goAddShoppingItem } from "./cart";
 const TOKEN = "token";
 const CART = "cart";
-import { emptyCart } from "./cart"
+import { emptyCart } from "./cart";
 
 /**
  * ACTION TYPES
@@ -31,19 +31,15 @@ export const me = () => async (dispatch) => {
     //check if there are items in a guest cart that need to be added to the backend cart for this user
     const frontEndCart = JSON.parse(window.localStorage.getItem(CART));
     if (frontEndCart) {
-      //go add the frontend cart to backEnd
-      frontEndCart.forEach(async (product) => {
-        console.log('product', product)
+      //go add the frontend cart to backEnd, and update the cart in redux store with the new information from the backend.
+      await frontEndCart.forEach(async (product) => {
         dispatch(goAddShoppingItem(product, id, product.qty));
       });
     }
 
-    // //get backend cart for this user.
-    // return (dispatch) => {
-      dispatch(fetchCart(id));
-      dispatch(setAuth(auth));
-    // }
-    // return
+    //get backend cart for this user.
+    //await dispatch(fetchCart(id));
+    dispatch(setAuth(auth));
   }
 };
 
@@ -64,7 +60,7 @@ export const logout = () => {
   history.push("/login");
   return (dispatch) => {
     dispatch(emptyCart());
-    dispatch(setAuth({}))
+    dispatch(setAuth({}));
   };
 };
 

--- a/client/store/auth.js
+++ b/client/store/auth.js
@@ -30,15 +30,27 @@ export const me = () => async (dispatch) => {
     const { id } = auth;
     //check if there are items in a guest cart that need to be added to the backend cart for this user
     const frontEndCart = JSON.parse(window.localStorage.getItem(CART));
+
+    const { data: backEndCart } = await axios.get(`/api/cart/${id}`, {
+      headers: {
+        authorization: token,
+      },
+    });
+
     if (frontEndCart) {
       //go add the frontend cart to backEnd, and update the cart in redux store with the new information from the backend.
-      await frontEndCart.forEach(async (product) => {
-        dispatch(goAddShoppingItem(product, id, product.qty));
+      await frontEndCart.forEach(async (frontEndProduct) => {
+        //get qty of the item that is already in this user's back end cart
+        let [productInBackEndCart] = backEndCart.filter(
+          (backEndProduct) => backEndProduct.id === frontEndProduct.id
+        );
+        let newQuantity = productInBackEndCart.qty + frontEndProduct.qty;
+        await dispatch(goAddShoppingItem(frontEndProduct, id, newQuantity));
       });
     }
 
     //get backend cart for this user.
-    //await dispatch(fetchCart(id));
+    dispatch(fetchCart(id));
     dispatch(setAuth(auth));
   }
 };

--- a/client/store/cart.js
+++ b/client/store/cart.js
@@ -47,16 +47,8 @@ export const emptyCart = () => {
   };
 };
 
-//if the component is not able to pass the item object to the action creator then we could use a thunk to get the item object from the database, but I don't think that will be needed.
-
 //THUNK CREATORS
-//need to create thunks to create shopping items for all the action creators.
-//need a thunk for when someone logs in.  it iwll need to do the following
-//convert any contents of a cart the user had assembled before logging in into shopping items.
-//it will need to fetch any shoppingItems with cart status in the databse for that user.  They will need to be added to the cart array in the reducer.
-
 export const fetchCart = (userId) => {
-  console.log('fetchcart beginning')
   return async (dispatch) => {
     try {
       const token = window.localStorage.getItem(TOKEN);
@@ -65,29 +57,7 @@ export const fetchCart = (userId) => {
           authorization: token,
         },
       });
-      // let cartMap = cart.map(item=> {
-      //   return item.itemName
-      // })
-      // let guestCart = (JSON.parse(window.localStorage.getItem(CART)));
-      // guestCart.forEach(item => {
-      //   if ( cartMap.includes(item.itemName)) {
-      //     for ( let i = 0 ; i < cart.length; i ++ ) {
-      //       if ( cart[i].itemName === item.itemName ) {
-      //         cart[i].qty+=1
-      //         //we need to update the DB for this shopping item.
-      //       }
-      //     }
-      //   } else {
-      //     cart.push(item)
-      //   }
-      // })
-      // // DOTHINGHERE
-
       dispatch(setCart(cart));
-      console.log('fetchcart ending')
-
-
-
     } catch (error) {
       console.log("there was a problem fetching this user's cart", error);
     }
@@ -95,12 +65,12 @@ export const fetchCart = (userId) => {
 };
 
 export const goAddShoppingItem = (item, userId, quantity) => {
-  console.log("goAddShoppingItem", item.itemName)
   return async (dispatch) => {
-    // console.log("***abc item***", item)
     try {
       const token = window.localStorage.getItem(TOKEN);
-      const { data: product } = await axios.post(`/api/cart/${userId}`, {
+
+      //make sure the user has a cart already (this route will create an empty cart for the user if they don't already have one)
+      await axios.get(`/api/cart/${userId}`, {
         headers: {
           authorization: token,
         },
@@ -108,7 +78,19 @@ export const goAddShoppingItem = (item, userId, quantity) => {
         quantity: quantity,
       });
 
-      dispatch(addItem(product));
+      //add the item to the cart(or update its qty if its already in there)
+      const { data: updatedCart } = await axios.put(
+        `/api/cart/${userId}/add-item`,
+        {
+          headers: {
+            authorization: token,
+          },
+          itemId: item.id,
+          quantity: quantity,
+        }
+      );
+
+      dispatch(setCart(updatedCart));
     } catch (err) {
       console.log(err);
     }
@@ -119,7 +101,7 @@ export const goUpdateShoppingItemQty = (item, userId, quantity) => {
   return async (dispatch) => {
     try {
       const token = window.localStorage.getItem(TOKEN);
-      const { data: product } = await axios.put(
+      const { data: updatedCart } = await axios.put(
         `/api/cart/${userId}/quantity-update`,
         {
           headers: {
@@ -129,7 +111,7 @@ export const goUpdateShoppingItemQty = (item, userId, quantity) => {
           quantity: quantity,
         }
       );
-      dispatch(updateItemQty(product, product.qty));
+      dispatch(setCart(updatedCart));
     } catch (err) {
       console.log(err);
     }
@@ -140,7 +122,7 @@ export const goRemoveShoppingItem = (item, userId) => {
   return async (dispatch) => {
     try {
       const token = window.localStorage.getItem(TOKEN);
-      const { data: newCart } = await axios.put(
+      const { data: updatedCart } = await axios.put(
         `/api/cart/${userId}/remove-item`,
         {
           headers: {
@@ -150,7 +132,7 @@ export const goRemoveShoppingItem = (item, userId) => {
         }
       );
 
-      dispatch(setCart(newCart));
+      dispatch(setCart(updatedCart));
     } catch (err) {
       console.log(err);
     }

--- a/client/store/cart.js
+++ b/client/store/cart.js
@@ -56,6 +56,7 @@ export const emptyCart = () => {
 //it will need to fetch any shoppingItems with cart status in the databse for that user.  They will need to be added to the cart array in the reducer.
 
 export const fetchCart = (userId) => {
+  console.log('fetchcart beginning')
   return async (dispatch) => {
     try {
       const token = window.localStorage.getItem(TOKEN);
@@ -64,25 +65,29 @@ export const fetchCart = (userId) => {
           authorization: token,
         },
       });
-      let cartMap = cart.map(item=> {
-        return item.itemName
-      })
-      let guestCart = (JSON.parse(window.localStorage.getItem(CART)));
-      guestCart.forEach(item => {
-        if ( cartMap.includes(item.itemName)) {
-          for ( let i = 0 ; i < cart.length; i ++ ) {
-            if ( cart[i].itemName === item.itemName ) {
-              cart[i].qty+=1
-            }
-          }
-        } else {
-          cart.push(item)
-        }
-      })
-      dispatch(setCart(cart));
-      
+      // let cartMap = cart.map(item=> {
+      //   return item.itemName
+      // })
+      // let guestCart = (JSON.parse(window.localStorage.getItem(CART)));
+      // guestCart.forEach(item => {
+      //   if ( cartMap.includes(item.itemName)) {
+      //     for ( let i = 0 ; i < cart.length; i ++ ) {
+      //       if ( cart[i].itemName === item.itemName ) {
+      //         cart[i].qty+=1
+      //         //we need to update the DB for this shopping item.
+      //       }
+      //     }
+      //   } else {
+      //     cart.push(item)
+      //   }
+      // })
+      // // DOTHINGHERE
 
-      
+      dispatch(setCart(cart));
+      console.log('fetchcart ending')
+
+
+
     } catch (error) {
       console.log("there was a problem fetching this user's cart", error);
     }
@@ -90,7 +95,9 @@ export const fetchCart = (userId) => {
 };
 
 export const goAddShoppingItem = (item, userId, quantity) => {
+  console.log("goAddShoppingItem", item.itemName)
   return async (dispatch) => {
+    // console.log("***abc item***", item)
     try {
       const token = window.localStorage.getItem(TOKEN);
       const { data: product } = await axios.post(`/api/cart/${userId}`, {

--- a/server/api/cart.js
+++ b/server/api/cart.js
@@ -4,14 +4,14 @@ const {
 } = require("../db");
 module.exports = router;
 
-//this function takes a backend inventoryItem (with an associated shopping item), and turns it into a front end cart item (where the qty value is a property directly on the item object rather than nested in the shopping item product in the cart)
-/*  backend cart:
+//this function takes a backend userPurchase that contains inventoryItems, and returns  a front end cart, i.e. an array of items where the qty is a property directly on the item object rather than nested in the shopping item product in the cart.
+/*  backend userPurchase:
 [
-    {   id:
+    inventoryItems: [{   id:
         name:
         shoppingItem:{
             qty:
-    }}
+    }}]
 
 ]
 frontend cart:
@@ -24,40 +24,38 @@ frontend cart:
     },
 */
 
-const makeFrontEndCartItem = (inventoryItem) => {
-  return {
-    id: inventoryItem.id,
-    itemName: inventoryItem.itemName,
-    itemDescription: inventoryItem.itemDescription,
-    itemPrice: inventoryItem.itemPrice,
-    itemImageUrl: inventoryItem.itemImageUrl,
-    qty: inventoryItem.shoppingItem.quantity,
-  };
-};
-
-const makeFrontEndCart = (backEndCart) => {
-  return backEndCart.map((cartItem) => {
-    return makeFrontEndCartItem(cartItem);
-  });
+const makeFrontEndCart = (userPurchase) => {
+  if (userPurchase.inventoryItems) {
+    return userPurchase.inventoryItems.map((inventoryItem) => {
+      return {
+        id: inventoryItem.id,
+        itemName: inventoryItem.itemName,
+        itemDescription: inventoryItem.itemDescription,
+        itemPrice: inventoryItem.itemPrice,
+        itemImageUrl: inventoryItem.itemImageUrl,
+        qty: inventoryItem.shoppingItem.quantity,
+      };
+    });
+  } else {
+    return [];
+  }
 };
 
 //get all the inventoryItems and their quantities that are shopping items in a purchase with cart status for a given user.
 router.get("/:userId", async (req, res, next) => {
   try {
     const id = req.params.userId;
-    const [userPurchases] = await Purchase.findAll({
+    const [userPurchase] = await Purchase.findOrCreate({
       where: {
         userId: id,
         status: "cart",
       },
       include: InventoryItem,
     });
-    const userCart = userPurchases.inventoryItems;
-    //the userCart is an array of inventoryItems which are in the cart.
 
-    //use this information to reformat the cart to be like the cart on the front end.
-    let frontEndCart = makeFrontEndCart(userCart);
-
+    // reformat the purchase to be like a frontend cart.
+    let frontEndCart = makeFrontEndCart(userPurchase);
+    //then send it to the front end.
     res.json(frontEndCart);
   } catch (err) {
     next(err);
@@ -65,14 +63,15 @@ router.get("/:userId", async (req, res, next) => {
 });
 
 //add an item to the shopping cart (or if it's already in the cart update its qty)
-router.post("/:userId", async (req, res, next) => {
+router.put("/:userId/add-item", async (req, res, next) => {
   try {
     //req.body will include the item id and the qty
     let { itemId, quantity } = req.body;
     const userId = req.params.userId;
+
     let inventoryItem = await InventoryItem.findByPk(itemId);
 
-    //does this user already have a cart?
+    //obtain the user's cart purchase (It is assumed that userPurchase is defined because this route should not be called if the user doesn't already have a cart)
     let [userPurchase] = await Purchase.findAll({
       where: {
         userId: userId,
@@ -81,39 +80,25 @@ router.post("/:userId", async (req, res, next) => {
       include: InventoryItem,
     });
 
-    if (userPurchase) {
-      //if the user has a cart check if it already has this inventoryItem in it.
-      let existingCart = userPurchase.inventoryItems;
-      let [itemInCart] = existingCart.filter((item) => item.id === itemId);
+    //determine whether the item to be added is already in the cart
+    let [itemInCart] = userPurchase.inventoryItems.filter(
+      (item) => item.id === itemId
+    );
 
-      if (itemInCart) {
-        //if the item is already in the cart, override the quantity of the associated shoppingItem with the new qty.
-        let existingShoppingItem = itemInCart.shoppingItem;
-        await existingShoppingItem.update({
-          quantity: quantity,
-        });
-      } else {
-        //if the item is not in the cart add it.
-        await userPurchase.addInventoryItem(inventoryItem, {
-          through: { quantity: quantity },
-        });
-      }
-    } else {
-      //if the user doesn't have a cart(i.e. a purchase with cart status), create one.
-      userPurchase = await Purchase.create({
-        userId: userId,
-        status: "cart",
+    //if the item is already in the cart override the quantity of the associated shoppingItem with the new qty.
+    if (itemInCart) {
+      let existingShoppingItem = itemInCart.shoppingItem;
+      await existingShoppingItem.update({
+        quantity: quantity,
       });
-
-      //add the inventory item to the new cart purchase in the database
+    } else {
+      //if the item is not in the cart add it.
       await userPurchase.addInventoryItem(inventoryItem, {
         through: { quantity: quantity },
       });
     }
 
-    //update our variables so that
-    //the cart now has the updated shoppingItem attached to it.
-    // the inventory item has the updated qty from the database.
+    //update the user purchase variable so that it has the updated shoppingItem attached to it.
     [userPurchase] = await Purchase.findAll({
       where: {
         userId: userId,
@@ -121,15 +106,12 @@ router.post("/:userId", async (req, res, next) => {
       },
       include: InventoryItem,
     });
-    [inventoryItem] = userPurchase.inventoryItems.filter(
-      (item) => item.id === itemId
-    );
 
-    //reformat the inventoryItem to match a frontend cartItem
-    let updatedCartItem = makeFrontEndCartItem(inventoryItem);
+    //reformat the purchase to be a frontend Cart.
+    const updatedFrontEndCart = makeFrontEndCart(userPurchase);
 
-    //send back the updated cart item
-    res.json(updatedCartItem);
+    //send the updated cart to the front end
+    res.json(updatedFrontEndCart);
   } catch (error) {
     next(error);
   }
@@ -159,9 +141,7 @@ router.put("/:userId/quantity-update", async (req, res, next) => {
       quantity: quantity,
     });
 
-    //update our variables so that
-    //the cart now has the updated shoppingItem attached to it.
-    // the inventory item has the updated qty from the database.
+    //update variable so that the userPurchase now has the updated shoppingItem attached to it.
     [userPurchase] = await Purchase.findAll({
       where: {
         userId: userId,
@@ -170,21 +150,15 @@ router.put("/:userId/quantity-update", async (req, res, next) => {
       include: InventoryItem,
     });
 
-    [inventoryItem] = userPurchase.inventoryItems.filter(
-      (item) => item.id === itemId
-    );
+    //reformat the purchase to be a frontend Cart.
+    const updatedFrontEndCart = makeFrontEndCart(userPurchase);
 
-    //reformat the inventoryItem to match a frontend cartItem
-    let updatedCartItem = makeFrontEndCartItem(inventoryItem);
-
-    //send back the updated cart item
-    res.json(updatedCartItem);
+    //send back the updated cart
+    res.json(updatedFrontEndCart);
   } catch (err) {
     next(err);
   }
 });
-
-//update a cart at the time of user log in to add everything that had been added to the cart on the frontend prior to log in to the databse cart
 
 //update the cart by removing an item.
 router.put("/:userId/remove-item", async (req, res, next) => {
@@ -205,7 +179,7 @@ router.put("/:userId/remove-item", async (req, res, next) => {
     let cart = userPurchase.inventoryItems;
 
     let [inventoryItem] = cart.filter((item) => item.id === itemId);
-    //console.log("inventoryItem to be deleted", inventoryItem);
+
     //remove the associate shopping item
     let shoppingItem = inventoryItem.shoppingItem;
     await shoppingItem.destroy();
@@ -220,7 +194,7 @@ router.put("/:userId/remove-item", async (req, res, next) => {
     });
 
     //send back the updated cart once it has been reformatted to match the front end.
-    let updatedCart = makeFrontEndCart(userPurchase.inventoryItems);
+    let updatedCart = makeFrontEndCart(userPurchase);
 
     res.json(updatedCart);
   } catch (error) {


### PR DESCRIPTION
I have done the following in this branch:

1. Addressed the issue in the singleProduct component Rafet pointed out in the slack where clicking add item multiple times was only working correctly for the first two clicks.  
- Proper behavior: first click should add item to the cart if it is not already in it.  after that it should just increment the existing cart item's qty.  
- Observed behavior: first click added item to cart, second click increment qty, further clicks added a duplicate of the item to the cart.  

This has been resolved so proper behavior is now what we see.

2. Addressed the issue where a guest user build a cart, then logs in, and their database cart from a previous log in session wasn't merging correctly.  
Proper behavior: 
- If the item is not in the back end cart, it should be added to the back end cart and kept in the front end cart.  
- If the item is in the back end cart and the front end cart the qty of the item in the front end and back end should be added together.  That should be the new qty for the item in the front end and back end.  
- If the item is in the back end but not the front end it should be added to the front end and kept in the back end.  The contents of front end cart and back end cart should match after merging.  

Observed behavior: 
- If the item is in the back end cart and the front end cart the qty in the back end would be updated to match what the front end qty had been.  The qty in the front end would be updated to match what the back end qty had been.  The front end and back end qty would not match.
- Sometimes a duplicate of an item would be added to the front end cart.

This has been resolved so proper behavior is now what we see.

3. Rewrote/ reorganized some of the backEnd cart routes and the front end cart thunks to be a little more restful (e.g. we will no longer create a purchase in a put route for the cart.  Instead we will use the get cart route to ensure that we do not call a put route for a cart that does not exist.)