### PR TITLE
Fix doubling cart bug

### DIFF
--- a/client/components/SingleProduct.js
+++ b/client/components/SingleProduct.js
@@ -85,6 +85,7 @@ const SingleProduct = (props) => {
               {product.itemDescription}
             </p>
             <p className="singleProductPrice">${product.itemPrice}</p>
+            {quantity ? <p>Quantity in Cart: {quantity}</p> : <p></p>}
             <button className="addButton" onClick={addToCart}>
               Add to Cart
             </button>

--- a/client/store/auth.js
+++ b/client/store/auth.js
@@ -19,7 +19,6 @@ const setAuth = (auth) => ({ type: SET_AUTH, auth });
  * THUNK CREATORS
  */
 export const me = () => async (dispatch) => {
-  console.log("me thunk is starting");
   const token = window.localStorage.getItem(TOKEN);
   if (token) {
     const { data: auth } = await axios.get("/auth/me", {
@@ -29,42 +28,16 @@ export const me = () => async (dispatch) => {
     });
 
     const { id } = auth;
-    // //check if there are items in a guest cart that need to be added to the backend cart for this user
-    // const frontEndCart = JSON.parse(window.localStorage.getItem(CART));
-
-    // const { data: backEndCart } = await axios.get(`/api/cart/${id}`, {
-    //   headers: {
-    //     authorization: token,
-    //   },
-    // });
-
-    // if (frontEndCart) {
-    //   //go add the frontend cart to backEnd, and update the cart in redux store with the new information from the backend.
-    //   await frontEndCart.forEach(async (frontEndProduct) => {
-    //     //get qty of the item that is already in this user's back end cart
-    //     let [productInBackEndCart] = backEndCart.filter(
-    //       (backEndProduct) => backEndProduct.id === frontEndProduct.id
-    //     );
-    //     let backEndQty = 0;
-    //     if (productInBackEndCart) {
-    //       backEndQty = productInBackEndCart.qty;
-    //     }
-    //     let newQuantity = backEndQty + frontEndProduct.qty;
-    //     await dispatch(goAddShoppingItem(frontEndProduct, id, newQuantity));
-    //   });
-    // }
 
     //get backend cart for this user.
     dispatch(fetchCart(id));
     dispatch(setAuth(auth));
-    console.log("me thunk is ending");
   }
 };
 
 export const authenticate =
   (username, password, method, email) => async (dispatch) => {
     try {
-      console.log("authenticate thunk is starting");
       //get a token based on log in information
       const res = await axios.post(`/auth/${method}`, {
         username,
@@ -72,10 +45,8 @@ export const authenticate =
         email,
       });
 
-      console.log("token from authenticate thunk", res.data.token);
       //put the token in local storage
       window.localStorage.setItem(TOKEN, res.data.token);
-      //dispatch(me());
 
       //get the user info based on their token
       const { data: auth } = await axios.get("/auth/me", {
@@ -84,12 +55,11 @@ export const authenticate =
         },
       });
       dispatch(setAuth(auth));
-      console.log("auth info from authenticate thunk", auth);
+
       const { id } = auth;
 
       //check if there are items in a guest cart that need to be added to the backend cart for this user
       const frontEndCart = JSON.parse(window.localStorage.getItem(CART));
-      console.log("frontend cart from authenticate thunk", frontEndCart);
 
       //check if there are items in the backend cart that need to be merged with front end cart.
       const { data: backEndCart } = await axios.get(`/api/cart/${id}`, {
@@ -97,8 +67,6 @@ export const authenticate =
           authorization: res.data.token,
         },
       });
-
-      console.log("backend cart from authenticate thunk", backEndCart);
 
       if (frontEndCart) {
         //go add the frontend cart to backEnd, then update the cart in redux store with the new information from the backend.
@@ -116,7 +84,7 @@ export const authenticate =
         });
       }
 
-      //get backend cart for this user.
+      //get backend cart for this user (this is still needed here in case there was nothing in the front end cart)
       dispatch(fetchCart(id));
     } catch (authError) {
       return dispatch(setAuth({ error: authError }));

--- a/client/store/auth.js
+++ b/client/store/auth.js
@@ -19,6 +19,7 @@ const setAuth = (auth) => ({ type: SET_AUTH, auth });
  * THUNK CREATORS
  */
 export const me = () => async (dispatch) => {
+  console.log("me thunk is starting");
   const token = window.localStorage.getItem(TOKEN);
   if (token) {
     const { data: auth } = await axios.get("/auth/me", {
@@ -28,47 +29,95 @@ export const me = () => async (dispatch) => {
     });
 
     const { id } = auth;
-    //check if there are items in a guest cart that need to be added to the backend cart for this user
-    const frontEndCart = JSON.parse(window.localStorage.getItem(CART));
+    // //check if there are items in a guest cart that need to be added to the backend cart for this user
+    // const frontEndCart = JSON.parse(window.localStorage.getItem(CART));
 
-    const { data: backEndCart } = await axios.get(`/api/cart/${id}`, {
-      headers: {
-        authorization: token,
-      },
-    });
+    // const { data: backEndCart } = await axios.get(`/api/cart/${id}`, {
+    //   headers: {
+    //     authorization: token,
+    //   },
+    // });
 
-    if (frontEndCart) {
-      //go add the frontend cart to backEnd, and update the cart in redux store with the new information from the backend.
-      await frontEndCart.forEach(async (frontEndProduct) => {
-        //get qty of the item that is already in this user's back end cart
-        let [productInBackEndCart] = backEndCart.filter(
-          (backEndProduct) => backEndProduct.id === frontEndProduct.id
-        );
-        let backEndQty = 0;
-        if (productInBackEndCart) {
-          backEndQty = productInBackEndCart.qty;
-        }
-        let newQuantity = backEndQty + frontEndProduct.qty;
-        await dispatch(goAddShoppingItem(frontEndProduct, id, newQuantity));
-      });
-    }
+    // if (frontEndCart) {
+    //   //go add the frontend cart to backEnd, and update the cart in redux store with the new information from the backend.
+    //   await frontEndCart.forEach(async (frontEndProduct) => {
+    //     //get qty of the item that is already in this user's back end cart
+    //     let [productInBackEndCart] = backEndCart.filter(
+    //       (backEndProduct) => backEndProduct.id === frontEndProduct.id
+    //     );
+    //     let backEndQty = 0;
+    //     if (productInBackEndCart) {
+    //       backEndQty = productInBackEndCart.qty;
+    //     }
+    //     let newQuantity = backEndQty + frontEndProduct.qty;
+    //     await dispatch(goAddShoppingItem(frontEndProduct, id, newQuantity));
+    //   });
+    // }
 
     //get backend cart for this user.
     dispatch(fetchCart(id));
     dispatch(setAuth(auth));
+    console.log("me thunk is ending");
   }
 };
 
 export const authenticate =
   (username, password, method, email) => async (dispatch) => {
     try {
+      console.log("authenticate thunk is starting");
+      //get a token based on log in information
       const res = await axios.post(`/auth/${method}`, {
         username,
         password,
         email,
       });
+
+      console.log("token from authenticate thunk", res.data.token);
+      //put the token in local storage
       window.localStorage.setItem(TOKEN, res.data.token);
-      dispatch(me());
+      //dispatch(me());
+
+      //get the user info based on their token
+      const { data: auth } = await axios.get("/auth/me", {
+        headers: {
+          authorization: res.data.token,
+        },
+      });
+      dispatch(setAuth(auth));
+      console.log("auth info from authenticate thunk", auth);
+      const { id } = auth;
+
+      //check if there are items in a guest cart that need to be added to the backend cart for this user
+      const frontEndCart = JSON.parse(window.localStorage.getItem(CART));
+      console.log("frontend cart from authenticate thunk", frontEndCart);
+
+      //check if there are items in the backend cart that need to be merged with front end cart.
+      const { data: backEndCart } = await axios.get(`/api/cart/${id}`, {
+        headers: {
+          authorization: res.data.token,
+        },
+      });
+
+      console.log("backend cart from authenticate thunk", backEndCart);
+
+      if (frontEndCart) {
+        //go add the frontend cart to backEnd, then update the cart in redux store with the new information from the backend.
+        await frontEndCart.forEach(async (frontEndProduct) => {
+          //get qty of the item that is already in this user's back end cart
+          let [productInBackEndCart] = backEndCart.filter(
+            (backEndProduct) => backEndProduct.id === frontEndProduct.id
+          );
+          let backEndQty = 0;
+          if (productInBackEndCart) {
+            backEndQty = productInBackEndCart.qty;
+          }
+          let newQuantity = backEndQty + frontEndProduct.qty;
+          await dispatch(goAddShoppingItem(frontEndProduct, id, newQuantity));
+        });
+      }
+
+      //get backend cart for this user.
+      dispatch(fetchCart(id));
     } catch (authError) {
       return dispatch(setAuth({ error: authError }));
     }

--- a/client/store/auth.js
+++ b/client/store/auth.js
@@ -1,6 +1,6 @@
 import axios from "axios";
 import history from "../history";
-import { fetchCart, goAddShoppingItem } from "./cart";
+import { fetchCart, mergeGuestCartwDBCart } from "./cart";
 const TOKEN = "token";
 const CART = "cart";
 import { emptyCart } from "./cart";
@@ -58,31 +58,7 @@ export const authenticate =
 
       const { id } = auth;
 
-      //check if there are items in a guest cart that need to be added to the backend cart for this user
-      const frontEndCart = JSON.parse(window.localStorage.getItem(CART));
-
-      //check if there are items in the backend cart that need to be merged with front end cart.
-      const { data: backEndCart } = await axios.get(`/api/cart/${id}`, {
-        headers: {
-          authorization: res.data.token,
-        },
-      });
-
-      if (frontEndCart) {
-        //go add the frontend cart to backEnd, then update the cart in redux store with the new information from the backend.
-        await frontEndCart.forEach(async (frontEndProduct) => {
-          //get qty of the item that is already in this user's back end cart
-          let [productInBackEndCart] = backEndCart.filter(
-            (backEndProduct) => backEndProduct.id === frontEndProduct.id
-          );
-          let backEndQty = 0;
-          if (productInBackEndCart) {
-            backEndQty = productInBackEndCart.qty;
-          }
-          let newQuantity = backEndQty + frontEndProduct.qty;
-          await dispatch(goAddShoppingItem(frontEndProduct, id, newQuantity));
-        });
-      }
+      dispatch(mergeGuestCartwDBCart(id));
 
       //get backend cart for this user (this is still needed here in case there was nothing in the front end cart)
       dispatch(fetchCart(id));

--- a/server/api/gatekeeping.js
+++ b/server/api/gatekeeping.js
@@ -13,17 +13,10 @@ const requireToken = async (req, res, next) => {
         token = req.body.headers.authorization;
       }
     }
-    // const token = req.headers.authorization
-    //   ? req.headers.authorization
-    //   : req.body.headers
-    // if (!token && !req.headers.authorization) {
-    //   throw new Error("bad token");
-    // }else {
 
-    // }
     const user = await User.findByToken(token);
     req.user = user;
-    console.log("requireToken running", user);
+
     next();
   } catch (error) {
     next(error);


### PR DESCRIPTION
Added feature in single part component that displays the quantity of that item in the cart (if the quantity is more than 0)

Fixed bug where the contents of a logged in user's cart was doubling every time the page was refreshed.
I did this by

- Creating a cart thunk to merge the front end and back end carts.  This logic had already been written, but it previously had been part of the me thunk, so I made it its own thunk in the cart reducer.  this just seemed more orderly.
- Moving the dispatch of the merge-front-end-back-end cart thunk from the  me() thunk into the authenticate thunk.  That way carts will only be compared and added together/merged at the time of log in, rather than on every refresh.
- To be able to call the merge-front-end-back-end cart thunk from within the authenticate thunk I needed to get access to the user id.  To do that I needed to make an axios call to get user info within the authenticate thunk (instead of waiting until the authenticate thunk dispatched the me thunk).  Once I'd done this in the authenticate thunk there was no point in dispatching the me thunk from within the authenticate thunk.  So that aspect of our code is a little less modular. but also less buggy.
